### PR TITLE
compare: mobile comparison switches working

### DIFF
--- a/src/components/Comparisons.tsx
+++ b/src/components/Comparisons.tsx
@@ -358,7 +358,7 @@ function Comparison(props: ComparisonProps) {
 
     return (
       <div className='relative flex w-full items-center justify-center'>
-        <object width='100%' data={src} className='' />
+        <object width='100%' data={src} />
       </div>
     );
   };

--- a/src/components/Comparisons.tsx
+++ b/src/components/Comparisons.tsx
@@ -358,12 +358,7 @@ function Comparison(props: ComparisonProps) {
 
     return (
       <div className='relative flex w-full items-center justify-center'>
-        <embed
-          width='100%'
-          src={src}
-          className=''
-          // alt={`Example of ${props.lang}`}
-        />
+        <img width='100%' src={src} className='' alt={props.name} />
       </div>
     );
   };

--- a/src/components/Comparisons.tsx
+++ b/src/components/Comparisons.tsx
@@ -358,7 +358,7 @@ function Comparison(props: ComparisonProps) {
 
     return (
       <div className='relative flex w-full items-center justify-center'>
-        <img width='100%' src={src} className='' alt={props.name} />
+        <object width='100%' data={src} className='' />
       </div>
     );
   };


### PR DESCRIPTION
Fixes: https://terrastruct.slack.com/archives/C03CLVB3LF5/p1667321884452139

Seems like something broken with embed tags, swapped to object tags and it works.

Broken (embed):

https://user-images.githubusercontent.com/6413609/199564047-9c94541e-e89a-4ab7-a79a-18295a8c2761.mp4

Fixed (object):

https://user-images.githubusercontent.com/6413609/199564134-88a2e185-53d5-42e6-bc3e-7dd169595780.mp4

Tested on desktop as well to see its still working