### PR TITLE
Fix wrong name PlantUML code error

### DIFF
--- a/src/examples/9_code/error/plantuml
+++ b/src/examples/9_code/error/plantuml
@@ -1,1 +1,1 @@
-Mermaid does not support code snippets currently.
+PlantUML does not support code snippets currently.


### PR DESCRIPTION
Probably a copy/paste error was made. This pull request fixes it.