### PR TITLE
Use &quot; HTML entity for mermaid double quotes

### DIFF
--- a/src/examples/10_wiiu/syntax/mermaid.mmd
+++ b/src/examples/10_wiiu/syntax/mermaid.mmd
@@ -1,6 +1,5 @@
 graph TD
-  %% I could not figure out how to use double quotes in labels in Mermaid
-  subgraph ibm[IBM Espresso CPU]
+  subgraph ibm[IBM &quot;Espresso&quot; CPU]
     core0[IBM PowerPC Broadway Core 0]
     core1[IBM PowerPC Broadway Core 1]
     core2[IBM PowerPC Broadway Core 2]


### PR DESCRIPTION
I couldn't get all the dependencies needed for rendering everything locally, but this seems to be the only way to support double quotes in label names with Mermaid.

You can see this working on the [mermaid playground](https://mermaid.live/edit#pako:eNp9k0FvozAQhf_KyIeeirYQ7a6UlSqFQKNoixqRVIpkenDjKUEb49QYlajqf1_bxAnJoTfmzWfPewN8ko3kSMakVGy_hVVS1ABN-9qX1aug8ziDm_dW6j9ps1fYNLKvYLp4frE0wEYqvHPgQn6gWkwhVpLxD3aAqWnB3YALv-HCARd9w0WG60klBQ1_wd8Y8qfspDo_EARBf9MANuK9FwGw5n3vFJgJTidZAo9Ma4TZKaFAQTMUUh3gBuY_noyhipd47HLFBE3ySWbs1VrJ3Q7VsYWuN4ogiyF1SJZmPqd1_zOMIIZlmi6GCRqmGV1OVhOYP_ibuoqm6_kZ8Z7Ljs7WR8jIbp4dF66CpRnoj_usZizjKGuXM3ePkP_uOpitz3s1ed3-yu6y7o9eLjSw3euDNsClYvx7yO7kijpJDhvY5VyNaASzGJIkH8Fxg96pv9xSjvbXeAGvFKu5z_DSuJna59MbcksEKsEqbv6KT9ssiN6iwIKMzSNn6l9BivrLcKzVcnmoN2SsVYu3RMm23JLxG9s1pmr3nGlMKmZek-iRr_93WQ2v).