### PR TITLE
Update D2 VS Code submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/extensions/d2-vscode"]
 	path = src/extensions/d2-vscode
-	url = https://github.com/terrastruct/d2-vscode
+	url = https://github.com/d2lang/d2-vscode
 [submodule "ci/sub"]
 	path = ci/sub
 	url = https://github.com/terrastruct/ci


### PR DESCRIPTION
## What changed

- Point the `src/extensions/d2-vscode` submodule directly at `d2lang/d2-vscode`.
- Keep the existing pinned submodule commit, so this does not update extension code or behavior.

## Why

The D2 VS Code repository moved from the Terrastruct organization to `d2lang`. Using the canonical URL avoids relying on GitHub's old-organization redirect and keeps fresh clones working if the Terrastruct organization is later retired.

## Impact

Future clones and submodule syncs fetch D2 VS Code directly from its new canonical repository. There is no runtime or dependency-version change.

## Validation

- `git diff --check`
- `git submodule sync -- src/extensions/d2-vscode`
- `git submodule update --init --depth 1 src/extensions/d2-vscode`
- Confirmed pinned commit `d722a70f36e634790eb60e86b678577af0e569c6` resolves from `https://github.com/d2lang/d2-vscode`.
- Searched tracked parent-repository files for stale links to moved D2 repositories; no other active references remain.
