### PR TITLE
site: canonicalize SEO GitHub organization

### DIFF
--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -115,7 +115,7 @@ export default function Seo(props: SeoProps) {
                   '@type': 'ImageObject',
                   url: 'https://text-to-diagram.com/svg/terrastruct.svg',
                 },
-                sameAs: ['https://github.com/terrastruct'],
+                sameAs: ['https://github.com/d2lang'],
               },
               {
                 '@type': 'WebPage',


### PR DESCRIPTION
## Summary

Update the final stale Terrastruct GitHub URL in JSON-LD organization metadata to the canonical `d2lang` organization.

## Validation

- Prettier check at the repository print width
- no remaining `github.com/terrastruct` references outside vendored submodules/lockfiles
- `git diff --check`