### PR TITLE
ci: remove legacy GitHub PAT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ concurrency:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -17,17 +20,16 @@ jobs:
             ${{ runner.os }}-yarn-
       - run: COLOR=1 ./make.sh
         env:
-          GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
   nofixups:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - run: git submodule update --init
       - run: COLOR=1 ./ci/sub/bin/nofixups.sh
-        env:
-          GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
   deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     needs: [ci, nofixups]

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -10,6 +10,9 @@ concurrency:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -20,5 +23,5 @@ jobs:
             ${{ runner.os }}-yarn-
       - run: COLOR=1 CI_FORCE=1 ./make.sh
         env:
-          GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary

- replace the legacy `_GITHUB_TOKEN` secret with GitHub Actions' per-run `github.token`
- grant only `actions: read` and `contents: read` to jobs that query workflow metadata
- remove unused token and Discord secret exposure from the `nofixups` job
- preserve the deploy job's existing read-only contents and AWS OIDC permissions

## Why

This repository retained a long-lived PAT from 2022 after its transfer to `d2lang`. The workflows only need read access to public submodules and the current run's job metadata, so a repository secret is unnecessary.

## Impact

CI, scheduled checks, and deployment behavior stay the same. The built-in token is short-lived and scoped to each workflow run. After merge, both protected-branch CI and a manually dispatched Daily workflow will be exercised before the old secret is deleted, then rerun after deletion.

## Validation

- `actionlint` 1.7.12
- YAML parse for both changed workflows
- `git diff --check`
- verified signed commit
